### PR TITLE
Replace k3d v5.4.9 with fixed version including #1252

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pvotal-tech/terraform-provider-k3d
 
 go 1.18
 
+replace github.com/k3d-io/k3d/v5 => github.com/moio/k3d/v5 v5.0.0-20230328124135-da29b7058f1e
+
 require (
 	github.com/docker/go-connections v0.4.0
 	github.com/hashicorp/terraform-plugin-docs v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k3d-io/k3d/v5 v5.4.9 h1:9x2N5L8zSDsT5aUIsUxTZC/UMmFsck62gJamjXsahTA=
-github.com/k3d-io/k3d/v5 v5.4.9/go.mod h1:vmAhXB2J/8wXyLbHkjcwfa9zPEpDlU1mGvexwgx52wg=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -435,6 +433,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/moio/k3d/v5 v5.0.0-20230328124135-da29b7058f1e h1:J8QF3xy2+pQN78O/1GDOma3PqOQmOG4AYLG4yOtsZ3g=
+github.com/moio/k3d/v5 v5.0.0-20230328124135-da29b7058f1e/go.mod h1:vmAhXB2J/8wXyLbHkjcwfa9zPEpDlU1mGvexwgx52wg=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=


### PR DESCRIPTION
[Bumping k3d to v5.4.9](https://github.com/pvotal-tech/terraform-provider-k3d/pull/55) breaks terraform-provider-k3d because of a regression in k3d.

[See the PR addressing that regression for details](https://github.com/k3d-io/k3d/pull/1252).

This is a temporary fix pointing to v5.4.9 + the patch for https://github.com/k3d-io/k3d/pull/1252, while the patch is merged upstream and a new version is cut.

Note that latest versions of k3s do not work due to k3d version being too old - I tested v1.24.12+k3s1 with v5.4.2 (currently embedded in `terraform-provider-k3d`) and it hangs on the `Starting Node` phase, v5.4.9 works fine.

**NOTE: this PR is to amend dependabot's! It's against the branch of #55, not `develop`**