### PR TITLE
Proxy registry support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,10 @@ require (
 	k8s.io/client-go v0.27.1
 )
 
+replace (
+	k8s.io/kubelet => k8s.io/kubelet v0.27.1
+)
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/internal/provider/resource_registry.go
+++ b/internal/provider/resource_registry.go
@@ -39,6 +39,13 @@ func resourceRegistry() *schema.Resource {
 				Type:        schema.TypeString,
 				Default:     fmt.Sprintf("%s:%s", types.DefaultRegistryImageRepo, types.DefaultRegistryImageTag),
 			},
+			"network": {
+				Description: "Join an existing network.",
+				Computed:    true,
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
 			"port": {
 				Description: "Select which port the registry should be listening on on your machine (localhost).",
 				ForceNew:    true,
@@ -118,6 +125,7 @@ func resourceRegistryCreate(ctx context.Context, d *schema.ResourceData, meta in
 		ExposureOpts: expandExposureOpts(d.Get("port").([]interface{})),
 		Host:         registryID,
 		Image:        d.Get("image").(string),
+		Network:      d.Get("network").(string),
 		Volumes:      expandRegistryVolumes(d.Get("volume").([]interface{})),
 
 		Options: types.RegistryOptions{

--- a/internal/provider/resource_registry.go
+++ b/internal/provider/resource_registry.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
-	"github.com/docker/go-connections/nat"
 
 	"github.com/k3d-io/k3d/v5/cmd/util"
 	"github.com/k3d-io/k3d/v5/pkg/client"
@@ -68,6 +67,45 @@ func resourceRegistry() *schema.Resource {
 					},
 				},
 			},
+			"proxy_remote_url": {
+				Description:  "URL of the proxied remote registry",
+				ForceNew:     true,
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+			},
+			"proxy_username": {
+				Description: "Username of the proxied remote registry",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"proxy_password": {
+				Description: "Password of the proxied remote registry",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+			"volume": {
+				Description: "Mount volumes into the registry node",
+				ForceNew:    true,
+				Optional:    true,
+				Type:        schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source": {
+							ForceNew: true,
+							Optional: true,
+							Type:     schema.TypeString,
+						},
+						"destination": {
+							ForceNew: true,
+							Required: true,
+							Type:     schema.TypeString,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -80,6 +118,15 @@ func resourceRegistryCreate(ctx context.Context, d *schema.ResourceData, meta in
 		ExposureOpts: expandExposureOpts(d.Get("port").([]interface{})),
 		Host:         registryID,
 		Image:        d.Get("image").(string),
+		Volumes:      expandRegistryVolumes(d.Get("volume").([]interface{})),
+
+		Options: types.RegistryOptions{
+			Proxy: types.RegistryProxy{
+				RemoteURL: d.Get("proxy_remote_url").(string),
+				Username:  d.Get("proxy_username").(string),
+				Password:  d.Get("proxy_password").(string),
+			},
+		},
 	}
 
 	if _, err := client.RegistryRun(ctx, runtimes.SelectedRuntime, registry); err != nil {
@@ -89,6 +136,26 @@ func resourceRegistryCreate(ctx context.Context, d *schema.ResourceData, meta in
 	d.SetId(registryID)
 
 	return resourceRegistryRead(ctx, d, meta)
+}
+
+func expandRegistryVolumes(l []interface{}) []string {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	volumes := make([]string, 0, len(l))
+	for _, i := range l {
+		v := i.(map[string]interface{})
+
+		volume := fmt.Sprintf("%s", v["destination"].(string))
+		if v["source"].(string) != "" {
+			volume = fmt.Sprintf("%s:%s", v["source"].(string), v["destination"].(string))
+		}
+
+		volumes = append(volumes, volume)
+	}
+
+	return volumes
 }
 
 func resourceRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
This PR adds support for two features:

1. Proxy registries. These allow to cache frequently-downloaded images on a local disk, and I found that very valuable when developing Rancher, as many big images are required, eg.

```hcl
resource "k3d_registry" "registry" {
  name = "${var.project_name}-registry"
  port {
    host_port = "5001"
  }
  proxy_remote_url = "https://registry-1.docker.io"

  volume {
    source      = "/tmp/docker-io-registry"
    destination = "/var/lib/registry"
  }
}
```

More at: https://k3d.io/v5.5.1/usage/registries/#creating-a-registry-proxy-pull-through-registry

2. specifying a custom network for registries, eg.

```hcl
resource "docker_network" "network" {
  name   = "${var.project_name}-k3d"
  driver = "bridge"
}

resource "k3d_registry" "registry" {
  name = "${var.project_name}-registry"
  port {
    host_port = "5001"
  }
  network = docker_network.network.name
}
```

That is useful if multiple clusters end up using the same images, so that you cache them once only.

All of the above has been tested manually from my fork.

Thanks for your dedication to this provider! I hope this helps.